### PR TITLE
Add testcase ip4r-explain.sql for index on new types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+NO_PGXS := 1
 
 MODULE_big = ip4r
 
@@ -11,7 +12,7 @@ SRC_SQL	= ip4r--2.4.sql \
 	  ip4r--unpackaged2.0--2.0.sql \
 	  ip4r--unpackaged1--2.0.sql
 DATA	= $(addprefix scripts/, $(SRC_SQL))
-REGRESS = ip4r $(REGRESS_$(MAJORVERSION))
+REGRESS = ip4r $(REGRESS_$(PG_MAJORVERSION)) ip4r-explain
 REGRESS_11 := ip4r-v11
 REGRESS_12 := $(REGRESS_11)
 else
@@ -26,6 +27,7 @@ DOCS	= README.ip4r
 OBJS_C	= ip4r_module.o ip4r.o ip6r.o ipaddr.o iprange.o raw_io.o
 OBJS	= $(addprefix src/, $(OBJS_C))
 INCS	= ipr.h ipr_internal.h
+SRCDIR = ./
 
 HEADERS = src/ipr.h
 
@@ -38,18 +40,10 @@ VPATH := $(dir $(firstword $(MAKEFILE_LIST)))
 endif
 endif
 
-ifndef NO_PGXS
-PG_CONFIG ?= pg_config
-PGXS = $(shell $(PG_CONFIG) --pgxs)
+PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
-else
-subdir = contrib/ip4r
-top_builddir = ../..
-include $(top_builddir)/src/Makefile.global
-include $(top_srcdir)/contrib/contrib-global.mk
-endif
 
-ifeq ($(filter-out 7.% 8.0 8.1 8.2 8.3, $(MAJORVERSION)),)
+ifeq ($(filter-out 7.% 8.0 8.1 8.2 8.3, $(PG_MAJORVERSION)),)
 $(error unsupported PostgreSQL version)
 endif
 
@@ -68,7 +62,7 @@ endif # VPATH
 
 ifndef EXTENSION
 
-ifeq ($(filter-out 8.4, $(MAJORVERSION)),)
+ifeq ($(filter-out 8.4, $(PG_MAJORVERSION)),)
 
 ip4r.sql.in: $(srcdir)/scripts/ip4r--2.4.sql $(srcdir)/tools/legacy.sed
 	sed -f $(srcdir)/tools/legacy.sed $< | sed -e '/^DO /,/^[$$]/d' >$@
@@ -97,8 +91,7 @@ installcheck:
 endif # VPATH
 
 else
-ifeq ($(filter-out 8.% 9.0, $(MAJORVERSION)),)
+ifeq ($(filter-out 8.% 9.0, $(PG_MAJORVERSION)),)
 $(error extension build not supported in versions before 9.1, use NO_EXTENSION=1)
 endif
 endif
-

--- a/expected/ip4r-explain.out
+++ b/expected/ip4r-explain.out
@@ -1,0 +1,716 @@
+-- predicates and indexing
+set enable_seqscan = "off";
+set enable_bitmapscan = "off";
+create table ipranges_exp (r iprange, r4 ip4r, r6 ip6r) distributed by (r);
+insert into ipranges_exp
+select r, null, r
+  from (select ip6r(regexp_replace(ls, E'(....(?!$))', E'\\1:', 'g')::ip6,
+                    regexp_replace(substring(ls for n+1) || substring(us from n+2),
+                                   E'(....(?!$))', E'\\1:', 'g')::ip6) as r
+          from (select md5(i || ' lower 1') as ls,
+                       md5(i || ' upper 1') as us,
+                       (i % 11) + (i/11 % 11) + (i/121 % 11) as n
+                  from generate_series(1,13310) i) s1) s2;
+insert into ipranges_exp
+select r, r, null
+  from (select ip4r(ip4 '0.0.0.0' + ((la & '::ffff:ffff') - ip6 '::'),
+                    ip4 '0.0.0.0' + ((( (la & ip6_netmask(127-n)) | (ua & ~ip6_netmask(127-n)) ) & '::ffff:ffff') - ip6 '::')) as r
+          from (select regexp_replace(md5(i || ' lower 2'), E'(....(?!$))', E'\\1:', 'g')::ip6 as la,
+                       regexp_replace(md5(i || ' upper 2'), E'(....(?!$))', E'\\1:', 'g')::ip6 as ua,
+                       (i % 11) + (i/11 % 11) + (i/121 % 11) as n
+                  from generate_series(1,1331) i) s1) s2;
+insert into ipranges_exp
+select r, null, r
+  from (select n::ip6 / 68 as r
+          from (select ((8192 + i/256)::numeric * (2::numeric ^ 112)
+                       + (131072 + (i % 256))::numeric * (2::numeric ^ 60)) as n
+                  from generate_series(0,4095) i) s1) s2;
+insert into ipranges_exp
+select r, r, null
+  from (select n / 28 as r
+          from (select ip4 '172.16.0.0' + (i * 256) as n
+                  from generate_series(0,4095) i) s1) s2;
+insert into ipranges_exp
+select r, null, r
+  from (select n::ip6 / 48 as r
+          from (select ((8192 + i/256)::numeric * (2::numeric ^ 112)
+                       + (i % 256)::numeric * (2::numeric ^ 84)) as n
+                  from generate_series(0,4095) i) s1) s2;
+insert into ipranges_exp
+select r, r, null
+  from (select n / 16 as r
+          from (select ip4 '128.0.0.0' + (i * 65536) as n
+                  from generate_series(0,4095) i) s1) s2;
+insert into ipranges_exp values ('-',null,null);
+create table ipaddrs_exp (a ipaddress, a4 ip4, a6 ip6) distributed by (a);
+insert into ipaddrs_exp
+select a, null, a
+  from (select regexp_replace(md5(i || ' address 1'), E'(....(?!$))', E'\\1:', 'g')::ip6 as a
+          from generate_series(1,256) i) s1;
+insert into ipaddrs_exp
+select a, a, null
+  from (select ip4 '0.0.0.0' + ((regexp_replace(md5(i || ' address 1'), E'(....(?!$))', E'\\1:', 'g')::ip6 & '::ffff:ffff') - '::') as a
+          from generate_series(1,16) i) s1;
+explain select * from ipranges_exp where r >>= '5555::' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r >>= '5555::'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r <<= '5555::/16' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r <<= '5555::/16'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r && '5555::/16' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000210.39..10000000210.56 rows=67 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000210.39..10000000210.56 rows=23 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=23 width=72)
+               Filter: (r && '5555::/16'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '5555::' order by r6;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r6 >>= '5555::'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 <<= '5555::/16' order by r6;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r6 <<= '5555::/16'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 && '5555::/16' order by r6;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000210.39..10000000210.56 rows=67 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=10000000210.39..10000000210.56 rows=23 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=23 width=72)
+               Filter: (r6 && '5555::/16'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '172.16.2.0' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r >>= '172.16.2.0'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r <<= '10.0.0.0/12' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r <<= '10.0.0.0/12'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r && '10.128.0.0/12' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000210.39..10000000210.56 rows=67 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000210.39..10000000210.56 rows=23 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=23 width=72)
+               Filter: (r && '10.128.0.0/12'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r4 >>= '172.16.2.0'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 <<= '10.0.0.0/12' order by r4;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r4 <<= '10.0.0.0/12'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 && '10.128.0.0/12' order by r4;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000210.39..10000000210.56 rows=67 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=10000000210.39..10000000210.56 rows=23 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=23 width=72)
+               Filter: (r4 && '10.128.0.0/12'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000:a123::' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r >>= '2001:0:0:2000:a123::'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r >>= '2001:0:0:2000::'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::/68' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r >>= '2001:0:0:2000::/68'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >> '2001:0:0:2000::/68' order by r;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r >> '2001:0:0:2000::/68'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000:a123::' order by r6;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r6 >>= '2001:0:0:2000:a123::'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::' order by r6;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r6 >>= '2001:0:0:2000::'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::/68' order by r6;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r6 >>= '2001:0:0:2000::/68'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >> '2001:0:0:2000::/68' order by r6;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r6 >> '2001:0:0:2000::/68'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0/28' order by r4;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r4 >>= '172.16.2.0/28'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 >> '172.16.2.0/28' order by r4;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000208.62..10000000208.66 rows=14 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=10000000208.62..10000000208.66 rows=5 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=10000000000.00..10000000208.38 rows=5 width=72)
+               Filter: (r4 >> '172.16.2.0/28'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipaddrs_exp where a between '8.0.0.0' and '15.0.0.0' order by a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000006.85..10000000006.85 rows=1 width=37)
+   Merge Key: a
+   ->  Sort  (cost=10000000006.85..10000000006.85 rows=1 width=37)
+         Sort Key: a
+         ->  Seq Scan on ipaddrs_exp  (cost=10000000000.00..10000000006.84 rows=1 width=37)
+               Filter: ((a >= '8.0.0.0'::ipaddress) AND (a <= '15.0.0.0'::ipaddress))
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipaddrs_exp where a4 between '8.0.0.0' and '15.0.0.0' order by a4;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000006.85..10000000006.85 rows=1 width=37)
+   Merge Key: a4
+   ->  Sort  (cost=10000000006.85..10000000006.85 rows=1 width=37)
+         Sort Key: a4
+         ->  Seq Scan on ipaddrs_exp  (cost=10000000000.00..10000000006.84 rows=1 width=37)
+               Filter: ((a4 >= '8.0.0.0'::ip4) AND (a4 <= '15.0.0.0'::ip4))
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+create index ipranges_exp_r on ipranges_exp using gist (r);
+create index ipranges_exp_r4 on ipranges_exp using gist (r4);
+create index ipranges_exp_r6 on ipranges_exp using gist (r6);
+create index ipaddrs_exp_a on ipaddrs_exp (a);
+create index ipaddrs_exp_a4 on ipaddrs_exp (a4);
+create index ipaddrs_exp_a6 on ipaddrs_exp (a6);
+analyze ipranges_exp;
+analyze ipaddrs_exp;
+explain select * from ipranges_exp where r >>= '5555::' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=60)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=60)
+               Index Cond: (r >>= '5555::'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r <<= '5555::/16' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=60)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=60)
+               Index Cond: (r <<= '5555::/16'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r && '5555::/16' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=7908.64..7909.02 rows=156 width=60)
+   Merge Key: r
+   ->  Sort  (cost=7908.64..7909.02 rows=52 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..7902.99 rows=52 width=60)
+               Index Cond: (r && '5555::/16'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '5555::' order by r6;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r6 >>= '5555::'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 <<= '5555::/16' order by r6;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r6 <<= '5555::/16'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 && '5555::/16' order by r6;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=7908.51..7908.90 rows=156 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=7908.51..7908.90 rows=52 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.15..7902.87 rows=52 width=60)
+               Index Cond: (r6 && '5555::/16'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '172.16.2.0' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=60)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=60)
+               Index Cond: (r >>= '172.16.2.0'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r <<= '10.0.0.0/12' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=60)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=60)
+               Index Cond: (r <<= '10.0.0.0/12'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r && '10.128.0.0/12' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=7908.64..7909.02 rows=156 width=60)
+   Merge Key: r
+   ->  Sort  (cost=7908.64..7909.02 rows=52 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..7902.99 rows=52 width=60)
+               Index Cond: (r && '10.128.0.0/12'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r4 >>= '172.16.2.0'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 <<= '10.0.0.0/12' order by r4;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r4 <<= '10.0.0.0/12'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 && '10.128.0.0/12' order by r4;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=7908.51..7908.90 rows=156 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=7908.51..7908.90 rows=52 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.15..7902.87 rows=52 width=60)
+               Index Cond: (r4 && '10.128.0.0/12'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000:a123::' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=60)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=60)
+               Index Cond: (r >>= '2001:0:0:2000:a123::'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=60)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=60)
+               Index Cond: (r >>= '2001:0:0:2000::'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::/68' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=60)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=60)
+               Index Cond: (r >>= '2001:0:0:2000::/68'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r >> '2001:0:0:2000::/68' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=60)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=60)
+               Index Cond: (r >> '2001:0:0:2000::/68'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000:a123::' order by r6;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r6 >>= '2001:0:0:2000:a123::'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::' order by r6;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r6 >>= '2001:0:0:2000::'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::/68' order by r6;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r6 >>= '2001:0:0:2000::/68'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r6 >> '2001:0:0:2000::/68' order by r6;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r6 >> '2001:0:0:2000::/68'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0/28' order by r4;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r4 >>= '172.16.2.0/28'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipranges_exp where r4 >> '172.16.2.0/28' order by r4;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=60)
+               Index Cond: (r4 >> '172.16.2.0/28'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select * from ipaddrs_exp where a between '8.0.0.0' and '15.0.0.0' order by a;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.15..300.14 rows=2 width=36)
+   Merge Key: a
+   ->  Index Scan using ipaddrs_exp_a on ipaddrs_exp  (cost=0.15..300.14 rows=1 width=36)
+         Index Cond: ((a >= '8.0.0.0'::ipaddress) AND (a <= '15.0.0.0'::ipaddress))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+explain select * from ipaddrs_exp where a4 between '8.0.0.0' and '15.0.0.0' order by a4;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.15..200.17 rows=1 width=36)
+   Merge Key: a4
+   ->  Index Scan using ipaddrs_exp_a4 on ipaddrs_exp  (cost=0.15..200.17 rows=1 width=36)
+         Index Cond: ((a4 >= '8.0.0.0'::ip4) AND (a4 <= '15.0.0.0'::ip4))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r >>= a.a) order by a,r;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=20000058491.49..20000058512.59 rows=8440 width=96)
+   Merge Key: a.a, r.r
+   ->  Sort  (cost=20000058491.49..20000058512.59 rows=2814 width=96)
+         Sort Key: a.a, r.r
+         ->  Nested Loop  (cost=20000000000.28..20000057941.14 rows=2814 width=96)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000016.60 rows=272 width=36)
+                     ->  Seq Scan on ipaddrs_exp a  (cost=10000000000.00..10000000005.72 rows=91 width=36)
+               ->  Index Scan using ipranges_exp_r on ipranges_exp r  (cost=0.28..70.68 rows=11 width=60)
+                     Index Cond: (r >>= (a.a)::iprange)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r4 >>= a.a4) order by a4,r4;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=20000036489.49..20000036510.59 rows=8440 width=96)
+   Merge Key: a.a4, r.r4
+   ->  Sort  (cost=20000036489.49..20000036510.59 rows=2814 width=96)
+         Sort Key: a.a4, r.r4
+         ->  Nested Loop  (cost=20000000000.15..20000035939.14 rows=2814 width=96)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000016.60 rows=272 width=36)
+                     ->  Seq Scan on ipaddrs_exp a  (cost=10000000000.00..10000000005.72 rows=91 width=36)
+               ->  Index Scan using ipranges_exp_r4 on ipranges_exp r  (cost=0.15..43.71 rows=11 width=60)
+                     Index Cond: (r4 >>= (a.a4)::ip4r)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r6 >>= a.a6) order by a6,r6;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=20000047289.49..20000047310.59 rows=8440 width=96)
+   Merge Key: a.a6, r.r6
+   ->  Sort  (cost=20000047289.49..20000047310.59 rows=2814 width=96)
+         Sort Key: a.a6, r.r6
+         ->  Nested Loop  (cost=20000000000.15..20000046739.14 rows=2814 width=96)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000016.60 rows=272 width=36)
+                     ->  Seq Scan on ipaddrs_exp a  (cost=10000000000.00..10000000005.72 rows=91 width=36)
+               ->  Index Scan using ipranges_exp_r6 on ipranges_exp r  (cost=0.15..56.95 rows=11 width=60)
+                     Index Cond: (r6 >>= (a.a6)::ip6r)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- index-only, on versions that support it:
+vacuum ipranges_exp;
+explain select r from ipranges_exp where r >>= '5555::' order by r;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.59..2701.67 rows=32 width=20)
+   Merge Key: r
+   ->  Sort  (cost=2701.59..2701.67 rows=11 width=20)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.28..2700.82 rows=11 width=20)
+               Index Cond: (r >>= '5555::'::iprange)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select r6 from ipranges_exp where r6 >>= '5555::' order by r6;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=32)
+   Merge Key: r6
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=32)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=32)
+               Index Cond: (r6 >>= '5555::'::ip6r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain select r4 from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2701.46..2701.54 rows=32 width=8)
+   Merge Key: r4
+   ->  Sort  (cost=2701.46..2701.54 rows=11 width=8)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.15..2700.70 rows=11 width=8)
+               Index Cond: (r4 >>= '172.16.2.0'::ip4r)
+ Optimizer: Postgres query optimizer
+(7 rows)
+

--- a/expected/ip4r-explain_optimizer.out
+++ b/expected/ip4r-explain_optimizer.out
@@ -1,0 +1,747 @@
+-- predicates and indexing
+set enable_seqscan = "off";
+set enable_bitmapscan = "off";
+create table ipranges_exp (r iprange, r4 ip4r, r6 ip6r) distributed by (r);
+insert into ipranges_exp
+select r, null, r
+  from (select ip6r(regexp_replace(ls, E'(....(?!$))', E'\\1:', 'g')::ip6,
+                    regexp_replace(substring(ls for n+1) || substring(us from n+2),
+                                   E'(....(?!$))', E'\\1:', 'g')::ip6) as r
+          from (select md5(i || ' lower 1') as ls,
+                       md5(i || ' upper 1') as us,
+                       (i % 11) + (i/11 % 11) + (i/121 % 11) as n
+                  from generate_series(1,13310) i) s1) s2;
+insert into ipranges_exp
+select r, r, null
+  from (select ip4r(ip4 '0.0.0.0' + ((la & '::ffff:ffff') - ip6 '::'),
+                    ip4 '0.0.0.0' + ((( (la & ip6_netmask(127-n)) | (ua & ~ip6_netmask(127-n)) ) & '::ffff:ffff') - ip6 '::')) as r
+          from (select regexp_replace(md5(i || ' lower 2'), E'(....(?!$))', E'\\1:', 'g')::ip6 as la,
+                       regexp_replace(md5(i || ' upper 2'), E'(....(?!$))', E'\\1:', 'g')::ip6 as ua,
+                       (i % 11) + (i/11 % 11) + (i/121 % 11) as n
+                  from generate_series(1,1331) i) s1) s2;
+insert into ipranges_exp
+select r, null, r
+  from (select n::ip6 / 68 as r
+          from (select ((8192 + i/256)::numeric * (2::numeric ^ 112)
+                       + (131072 + (i % 256))::numeric * (2::numeric ^ 60)) as n
+                  from generate_series(0,4095) i) s1) s2;
+insert into ipranges_exp
+select r, r, null
+  from (select n / 28 as r
+          from (select ip4 '172.16.0.0' + (i * 256) as n
+                  from generate_series(0,4095) i) s1) s2;
+insert into ipranges_exp
+select r, null, r
+  from (select n::ip6 / 48 as r
+          from (select ((8192 + i/256)::numeric * (2::numeric ^ 112)
+                       + (i % 256)::numeric * (2::numeric ^ 84)) as n
+                  from generate_series(0,4095) i) s1) s2;
+insert into ipranges_exp
+select r, r, null
+  from (select n / 16 as r
+          from (select ip4 '128.0.0.0' + (i * 65536) as n
+                  from generate_series(0,4095) i) s1) s2;
+insert into ipranges_exp values ('-',null,null);
+create table ipaddrs_exp (a ipaddress, a4 ip4, a6 ip6) distributed by (a);
+insert into ipaddrs_exp
+select a, null, a
+  from (select regexp_replace(md5(i || ' address 1'), E'(....(?!$))', E'\\1:', 'g')::ip6 as a
+          from generate_series(1,256) i) s1;
+insert into ipaddrs_exp
+select a, a, null
+  from (select ip4 '0.0.0.0' + ((regexp_replace(md5(i || ' address 1'), E'(....(?!$))', E'\\1:', 'g')::ip6 & '::ffff:ffff') - '::') as a
+          from generate_series(1,16) i) s1;
+explain select * from ipranges_exp where r >>= '5555::' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r >>= '5555::'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r <<= '5555::/16' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r <<= '5555::/16'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r && '5555::/16' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r && '5555::/16'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '5555::' order by r6;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r6 >>= '5555::'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r6 <<= '5555::/16' order by r6;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r6 <<= '5555::/16'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r6 && '5555::/16' order by r6;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r6 && '5555::/16'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '172.16.2.0' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r >>= '172.16.2.0'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r <<= '10.0.0.0/12' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r <<= '10.0.0.0/12'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r && '10.128.0.0/12' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r && '10.128.0.0/12'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r4 >>= '172.16.2.0'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r4 <<= '10.0.0.0/12' order by r4;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r4 <<= '10.0.0.0/12'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r4 && '10.128.0.0/12' order by r4;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r4 && '10.128.0.0/12'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000:a123::' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r >>= '2001:0:0:2000:a123::'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r >>= '2001:0:0:2000::'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::/68' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r >>= '2001:0:0:2000::/68'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r >> '2001:0:0:2000::/68' order by r;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r >> '2001:0:0:2000::/68'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000:a123::' order by r6;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r6 >>= '2001:0:0:2000:a123::'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::' order by r6;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r6 >>= '2001:0:0:2000::'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::/68' order by r6;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r6 >>= '2001:0:0:2000::/68'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r6 >> '2001:0:0:2000::/68' order by r6;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r6
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r6 >> '2001:0:0:2000::/68'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0/28' order by r4;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r4 >>= '172.16.2.0/28'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipranges_exp where r4 >> '172.16.2.0/28' order by r4;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..440.88 rows=5324 width=72)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..439.45 rows=1775 width=72)
+         Sort Key: r4
+         ->  Seq Scan on ipranges_exp  (cost=0.00..431.63 rows=1775 width=72)
+               Filter: (r4 >> '172.16.2.0/28'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipaddrs_exp where a between '8.0.0.0' and '15.0.0.0' order by a;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.02 rows=41 width=37)
+   Merge Key: a
+   ->  Sort  (cost=0.00..431.02 rows=14 width=37)
+         Sort Key: a
+         ->  Seq Scan on ipaddrs_exp  (cost=0.00..431.01 rows=14 width=37)
+               Filter: ((a >= '8.0.0.0'::ipaddress) AND (a <= '15.0.0.0'::ipaddress))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain select * from ipaddrs_exp where a4 between '8.0.0.0' and '15.0.0.0' order by a4;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.02 rows=41 width=37)
+   Merge Key: a4
+   ->  Sort  (cost=0.00..431.02 rows=14 width=37)
+         Sort Key: a4
+         ->  Seq Scan on ipaddrs_exp  (cost=0.00..431.01 rows=14 width=37)
+               Filter: ((a4 >= '8.0.0.0'::ip4) AND (a4 <= '15.0.0.0'::ip4))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+create index ipranges_exp_r on ipranges_exp using gist (r);
+create index ipranges_exp_r4 on ipranges_exp using gist (r4);
+create index ipranges_exp_r6 on ipranges_exp using gist (r6);
+create index ipaddrs_exp_a on ipaddrs_exp (a);
+create index ipaddrs_exp_a4 on ipaddrs_exp (a4);
+create index ipaddrs_exp_a6 on ipaddrs_exp (a6);
+analyze ipranges_exp;
+analyze ipaddrs_exp;
+explain select * from ipranges_exp where r >>= '5555::' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r >>= '5555::'::iprange)
+               Filter: (r >>= '5555::'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r <<= '5555::/16' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r <<= '5555::/16'::iprange)
+               Filter: (r <<= '5555::/16'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r && '5555::/16' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r && '5555::/16'::iprange)
+               Filter: (r && '5555::/16'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r6 >>= '5555::' order by r6;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r6 >>= '5555::'::ip6r)
+               Filter: (r6 >>= '5555::'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r6 <<= '5555::/16' order by r6;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r6 <<= '5555::/16'::ip6r)
+               Filter: (r6 <<= '5555::/16'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r6 && '5555::/16' order by r6;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r6 && '5555::/16'::ip6r)
+               Filter: (r6 && '5555::/16'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r >>= '172.16.2.0' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r >>= '172.16.2.0'::iprange)
+               Filter: (r >>= '172.16.2.0'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r <<= '10.0.0.0/12' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r <<= '10.0.0.0/12'::iprange)
+               Filter: (r <<= '10.0.0.0/12'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r && '10.128.0.0/12' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r && '10.128.0.0/12'::iprange)
+               Filter: (r && '10.128.0.0/12'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r4 >>= '172.16.2.0'::ip4r)
+               Filter: (r4 >>= '172.16.2.0'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r4 <<= '10.0.0.0/12' order by r4;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r4 <<= '10.0.0.0/12'::ip4r)
+               Filter: (r4 <<= '10.0.0.0/12'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r4 && '10.128.0.0/12' order by r4;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r4 && '10.128.0.0/12'::ip4r)
+               Filter: (r4 && '10.128.0.0/12'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000:a123::' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r >>= '2001:0:0:2000:a123::'::iprange)
+               Filter: (r >>= '2001:0:0:2000:a123::'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r >>= '2001:0:0:2000::'::iprange)
+               Filter: (r >>= '2001:0:0:2000::'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::/68' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r >>= '2001:0:0:2000::/68'::iprange)
+               Filter: (r >>= '2001:0:0:2000::/68'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r >> '2001:0:0:2000::/68' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r >> '2001:0:0:2000::/68'::iprange)
+               Filter: (r >> '2001:0:0:2000::/68'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000:a123::' order by r6;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r6 >>= '2001:0:0:2000:a123::'::ip6r)
+               Filter: (r6 >>= '2001:0:0:2000:a123::'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::' order by r6;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r6 >>= '2001:0:0:2000::'::ip6r)
+               Filter: (r6 >>= '2001:0:0:2000::'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::/68' order by r6;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r6 >>= '2001:0:0:2000::/68'::ip6r)
+               Filter: (r6 >>= '2001:0:0:2000::/68'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r6 >> '2001:0:0:2000::/68' order by r6;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r6 >> '2001:0:0:2000::/68'::ip6r)
+               Filter: (r6 >> '2001:0:0:2000::/68'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0/28' order by r4;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r4 >>= '172.16.2.0/28'::ip4r)
+               Filter: (r4 >>= '172.16.2.0/28'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipranges_exp where r4 >> '172.16.2.0/28' order by r4;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..28.33 rows=12411 width=60)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..25.55 rows=4137 width=60)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.00..8.64 rows=4137 width=60)
+               Index Cond: (r4 >> '172.16.2.0/28'::ip4r)
+               Filter: (r4 >> '172.16.2.0/28'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select * from ipaddrs_exp where a between '8.0.0.0' and '15.0.0.0' order by a;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.01 rows=44 width=36)
+   Merge Key: a
+   ->  Index Scan using ipaddrs_exp_a on ipaddrs_exp  (cost=0.00..6.01 rows=15 width=36)
+         Index Cond: ((a >= '8.0.0.0'::ipaddress) AND (a <= '15.0.0.0'::ipaddress))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+explain select * from ipaddrs_exp where a4 between '8.0.0.0' and '15.0.0.0' order by a4;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.01 rows=44 width=36)
+   Merge Key: a4
+   ->  Index Scan using ipaddrs_exp_a4 on ipaddrs_exp  (cost=0.00..6.01 rows=15 width=36)
+         Index Cond: ((a4 >= '8.0.0.0'::ip4) AND (a4 <= '15.0.0.0'::ip4))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r >>= a.a) order by a,r;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..16641.31 rows=3375629 width=96)
+   Merge Key: ipaddrs_exp.a, ipranges_exp.r
+   ->  Sort  (cost=0.00..15433.64 rows=1125210 width=96)
+         Sort Key: ipaddrs_exp.a, ipranges_exp.r
+         ->  Nested Loop  (cost=0.00..3121.83 rows=1125210 width=96)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.18 rows=272 width=36)
+                     ->  Seq Scan on ipaddrs_exp  (cost=0.00..431.00 rows=91 width=36)
+               ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..2312.57 rows=1655 width=60)
+                     Index Cond: (r >>= (ipaddrs_exp.a)::iprange)
+                     Filter: (r >>= (ipaddrs_exp.a)::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r4 >>= a.a4) order by a4,r4;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..16641.31 rows=3375629 width=96)
+   Merge Key: ipaddrs_exp.a4, ipranges_exp.r4
+   ->  Sort  (cost=0.00..15433.64 rows=1125210 width=96)
+         Sort Key: ipaddrs_exp.a4, ipranges_exp.r4
+         ->  Nested Loop  (cost=0.00..3121.83 rows=1125210 width=96)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.18 rows=272 width=36)
+                     ->  Seq Scan on ipaddrs_exp  (cost=0.00..431.00 rows=91 width=36)
+               ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.00..2312.57 rows=1655 width=60)
+                     Index Cond: (r4 >>= (ipaddrs_exp.a4)::ip4r)
+                     Filter: (r4 >>= (ipaddrs_exp.a4)::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r6 >>= a.a6) order by a6,r6;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..16641.31 rows=3375629 width=96)
+   Merge Key: ipaddrs_exp.a6, ipranges_exp.r6
+   ->  Sort  (cost=0.00..15433.64 rows=1125210 width=96)
+         Sort Key: ipaddrs_exp.a6, ipranges_exp.r6
+         ->  Nested Loop  (cost=0.00..3121.83 rows=1125210 width=96)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.18 rows=272 width=36)
+                     ->  Seq Scan on ipaddrs_exp  (cost=0.00..431.00 rows=91 width=36)
+               ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..2312.57 rows=1655 width=60)
+                     Index Cond: (r6 >>= (ipaddrs_exp.a6)::ip6r)
+                     Filter: (r6 >>= (ipaddrs_exp.a6)::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+-- index-only, on versions that support it:
+vacuum ipranges_exp;
+explain select r from ipranges_exp where r >>= '5555::' order by r;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..14.90 rows=12411 width=20)
+   Merge Key: r
+   ->  Sort  (cost=0.00..13.97 rows=4137 width=20)
+         Sort Key: r
+         ->  Index Scan using ipranges_exp_r on ipranges_exp  (cost=0.00..8.34 rows=4137 width=20)
+               Index Cond: (r >>= '5555::'::iprange)
+               Filter: (r >>= '5555::'::iprange)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select r6 from ipranges_exp where r6 >>= '5555::' order by r6;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..18.93 rows=12411 width=32)
+   Merge Key: r6
+   ->  Sort  (cost=0.00..17.45 rows=4137 width=32)
+         Sort Key: r6
+         ->  Index Scan using ipranges_exp_r6 on ipranges_exp  (cost=0.00..8.43 rows=4137 width=32)
+               Index Cond: (r6 >>= '5555::'::ip6r)
+               Filter: (r6 >>= '5555::'::ip6r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain select r4 from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..10.87 rows=12411 width=8)
+   Merge Key: r4
+   ->  Sort  (cost=0.00..10.50 rows=4137 width=8)
+         Sort Key: r4
+         ->  Index Scan using ipranges_exp_r4 on ipranges_exp  (cost=0.00..8.24 rows=4137 width=8)
+               Index Cond: (r4 >>= '172.16.2.0'::ip4r)
+               Filter: (r4 >>= '172.16.2.0'::ip4r)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+

--- a/expected/ip4r.out
+++ b/expected/ip4r.out
@@ -7897,7 +7897,7 @@ ERROR:  ip address out of range
 select a::ipaddress - 4294967296::bigint from (select ip4 '255.255.255.255' as a) s;
 ERROR:  ip address out of range
 -- predicates and indexing
-create table ipranges (r iprange, r4 ip4r, r6 ip6r);
+create table ipranges (r iprange, r4 ip4r, r6 ip6r) distributed by (r);
 insert into ipranges
 select r, null, r
   from (select ip6r(regexp_replace(ls, E'(....(?!$))', E'\\1:', 'g')::ip6,
@@ -7938,7 +7938,7 @@ select r, r, null
           from (select ip4 '128.0.0.0' + (i * 65536) as n
                   from generate_series(0,4095) i) s1) s2;
 insert into ipranges values ('-',null,null);
-create table ipaddrs (a ipaddress, a4 ip4, a6 ip6);
+create table ipaddrs (a ipaddress, a4 ip4, a6 ip6) distributed by (a);
 insert into ipaddrs
 select a, null, a
   from (select regexp_replace(md5(i || ' address 1'), E'(....(?!$))', E'\\1:', 'g')::ip6 as a
@@ -8730,6 +8730,7 @@ select * from ipaddrs a join ipranges r on (r.r6 >>= a.a6) order by a6,r6;
 
 -- index-only, on versions that support it:
 vacuum ipranges;
+analyze ipranges;
 select r from ipranges where r >>= '5555::' order by r;
                                        r                                        
 --------------------------------------------------------------------------------

--- a/sql/ip4r-explain.sql
+++ b/sql/ip4r-explain.sql
@@ -1,0 +1,145 @@
+-- predicates and indexing
+
+set enable_seqscan = "off";
+set enable_bitmapscan = "off";
+
+create table ipranges_exp (r iprange, r4 ip4r, r6 ip6r) distributed by (r);
+
+insert into ipranges_exp
+select r, null, r
+  from (select ip6r(regexp_replace(ls, E'(....(?!$))', E'\\1:', 'g')::ip6,
+                    regexp_replace(substring(ls for n+1) || substring(us from n+2),
+                                   E'(....(?!$))', E'\\1:', 'g')::ip6) as r
+          from (select md5(i || ' lower 1') as ls,
+                       md5(i || ' upper 1') as us,
+                       (i % 11) + (i/11 % 11) + (i/121 % 11) as n
+                  from generate_series(1,13310) i) s1) s2;
+
+insert into ipranges_exp
+select r, r, null
+  from (select ip4r(ip4 '0.0.0.0' + ((la & '::ffff:ffff') - ip6 '::'),
+                    ip4 '0.0.0.0' + ((( (la & ip6_netmask(127-n)) | (ua & ~ip6_netmask(127-n)) ) & '::ffff:ffff') - ip6 '::')) as r
+          from (select regexp_replace(md5(i || ' lower 2'), E'(....(?!$))', E'\\1:', 'g')::ip6 as la,
+                       regexp_replace(md5(i || ' upper 2'), E'(....(?!$))', E'\\1:', 'g')::ip6 as ua,
+                       (i % 11) + (i/11 % 11) + (i/121 % 11) as n
+                  from generate_series(1,1331) i) s1) s2;
+
+insert into ipranges_exp
+select r, null, r
+  from (select n::ip6 / 68 as r
+          from (select ((8192 + i/256)::numeric * (2::numeric ^ 112)
+                       + (131072 + (i % 256))::numeric * (2::numeric ^ 60)) as n
+                  from generate_series(0,4095) i) s1) s2;
+
+insert into ipranges_exp
+select r, r, null
+  from (select n / 28 as r
+          from (select ip4 '172.16.0.0' + (i * 256) as n
+                  from generate_series(0,4095) i) s1) s2;
+
+insert into ipranges_exp
+select r, null, r
+  from (select n::ip6 / 48 as r
+          from (select ((8192 + i/256)::numeric * (2::numeric ^ 112)
+                       + (i % 256)::numeric * (2::numeric ^ 84)) as n
+                  from generate_series(0,4095) i) s1) s2;
+
+insert into ipranges_exp
+select r, r, null
+  from (select n / 16 as r
+          from (select ip4 '128.0.0.0' + (i * 65536) as n
+                  from generate_series(0,4095) i) s1) s2;
+
+insert into ipranges_exp values ('-',null,null);
+
+create table ipaddrs_exp (a ipaddress, a4 ip4, a6 ip6) distributed by (a);
+
+insert into ipaddrs_exp
+select a, null, a
+  from (select regexp_replace(md5(i || ' address 1'), E'(....(?!$))', E'\\1:', 'g')::ip6 as a
+          from generate_series(1,256) i) s1;
+
+insert into ipaddrs_exp
+select a, a, null
+  from (select ip4 '0.0.0.0' + ((regexp_replace(md5(i || ' address 1'), E'(....(?!$))', E'\\1:', 'g')::ip6 & '::ffff:ffff') - '::') as a
+          from generate_series(1,16) i) s1;
+
+explain select * from ipranges_exp where r >>= '5555::' order by r;
+explain select * from ipranges_exp where r <<= '5555::/16' order by r;
+explain select * from ipranges_exp where r && '5555::/16' order by r;
+explain select * from ipranges_exp where r6 >>= '5555::' order by r6;
+explain select * from ipranges_exp where r6 <<= '5555::/16' order by r6;
+explain select * from ipranges_exp where r6 && '5555::/16' order by r6;
+explain select * from ipranges_exp where r >>= '172.16.2.0' order by r;
+explain select * from ipranges_exp where r <<= '10.0.0.0/12' order by r;
+explain select * from ipranges_exp where r && '10.128.0.0/12' order by r;
+explain select * from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
+explain select * from ipranges_exp where r4 <<= '10.0.0.0/12' order by r4;
+explain select * from ipranges_exp where r4 && '10.128.0.0/12' order by r4;
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000:a123::' order by r;
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::' order by r;
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::/68' order by r;
+explain select * from ipranges_exp where r >> '2001:0:0:2000::/68' order by r;
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000:a123::' order by r6;
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::' order by r6;
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::/68' order by r6;
+explain select * from ipranges_exp where r6 >> '2001:0:0:2000::/68' order by r6;
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0/28' order by r4;
+explain select * from ipranges_exp where r4 >> '172.16.2.0/28' order by r4;
+
+explain select * from ipaddrs_exp where a between '8.0.0.0' and '15.0.0.0' order by a;
+explain select * from ipaddrs_exp where a4 between '8.0.0.0' and '15.0.0.0' order by a4;
+
+create index ipranges_exp_r on ipranges_exp using gist (r);
+create index ipranges_exp_r4 on ipranges_exp using gist (r4);
+create index ipranges_exp_r6 on ipranges_exp using gist (r6);
+create index ipaddrs_exp_a on ipaddrs_exp (a);
+create index ipaddrs_exp_a4 on ipaddrs_exp (a4);
+create index ipaddrs_exp_a6 on ipaddrs_exp (a6);
+
+analyze ipranges_exp;
+analyze ipaddrs_exp;
+
+explain select * from ipranges_exp where r >>= '5555::' order by r;
+explain select * from ipranges_exp where r <<= '5555::/16' order by r;
+explain select * from ipranges_exp where r && '5555::/16' order by r;
+explain select * from ipranges_exp where r6 >>= '5555::' order by r6;
+explain select * from ipranges_exp where r6 <<= '5555::/16' order by r6;
+explain select * from ipranges_exp where r6 && '5555::/16' order by r6;
+explain select * from ipranges_exp where r >>= '172.16.2.0' order by r;
+explain select * from ipranges_exp where r <<= '10.0.0.0/12' order by r;
+explain select * from ipranges_exp where r && '10.128.0.0/12' order by r;
+explain select * from ipranges_exp where r4 >>= '172.16.2.0' order by r4;
+explain select * from ipranges_exp where r4 <<= '10.0.0.0/12' order by r4;
+explain select * from ipranges_exp where r4 && '10.128.0.0/12' order by r4;
+
+explain select * from ipranges_exp where r >>= '2001:0:0:2000:a123::' order by r;
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::' order by r;
+explain select * from ipranges_exp where r >>= '2001:0:0:2000::/68' order by r;
+explain select * from ipranges_exp where r >> '2001:0:0:2000::/68' order by r;
+
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000:a123::' order by r6;
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::' order by r6;
+explain select * from ipranges_exp where r6 >>= '2001:0:0:2000::/68' order by r6;
+explain select * from ipranges_exp where r6 >> '2001:0:0:2000::/68' order by r6;
+
+explain select * from ipranges_exp where r4 >>= '172.16.2.0/28' order by r4;
+explain select * from ipranges_exp where r4 >> '172.16.2.0/28' order by r4;
+
+explain select * from ipaddrs_exp where a between '8.0.0.0' and '15.0.0.0' order by a;
+explain select * from ipaddrs_exp where a4 between '8.0.0.0' and '15.0.0.0' order by a4;
+
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r >>= a.a) order by a,r;
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r4 >>= a.a4) order by a4,r4;
+explain select * from ipaddrs_exp a join ipranges_exp r on (r.r6 >>= a.a6) order by a6,r6;
+
+-- index-only, on versions that support it:
+
+vacuum ipranges_exp;
+
+explain select r from ipranges_exp where r >>= '5555::' order by r;
+explain select r6 from ipranges_exp where r6 >>= '5555::' order by r6;
+explain select r4 from ipranges_exp where r4 >>= '172.16.2.0' order by r4;

--- a/sql/ip4r.sql
+++ b/sql/ip4r.sql
@@ -2035,7 +2035,7 @@ select a::ipaddress - 4294967296::bigint from (select ip4 '255.255.255.255' as a
 
 -- predicates and indexing
 
-create table ipranges (r iprange, r4 ip4r, r6 ip6r);
+create table ipranges (r iprange, r4 ip4r, r6 ip6r) distributed by (r);
 
 insert into ipranges
 select r, null, r
@@ -2084,7 +2084,7 @@ select r, r, null
 
 insert into ipranges values ('-',null,null);
 
-create table ipaddrs (a ipaddress, a4 ip4, a6 ip6);
+create table ipaddrs (a ipaddress, a4 ip4, a6 ip6) distributed by (a);
 
 insert into ipaddrs
 select a, null, a
@@ -2168,6 +2168,7 @@ select * from ipaddrs a join ipranges r on (r.r6 >>= a.a6) order by a6,r6;
 -- index-only, on versions that support it:
 
 vacuum ipranges;
+analyze ipranges;
 
 select r from ipranges where r >>= '5555::' order by r;
 select r6 from ipranges where r6 >>= '5555::' order by r6;

--- a/src/ip4r.c
+++ b/src/ip4r.c
@@ -904,8 +904,9 @@ ip4r_cast_to_bit(PG_FUNCTION_ARGS)
 	unsigned char buf[4];
 	int len;
 
-    if (bits > 32)
+    if (bits > 32) {
         PG_RETURN_NULL();
+    }
 
 	len = VARBITTOTALLEN(bits);
     res = palloc0(len);

--- a/src/ip6r.c
+++ b/src/ip6r.c
@@ -978,8 +978,9 @@ ip6r_cast_to_bit(PG_FUNCTION_ARGS)
 	unsigned char buf[16];
 	int len;
 
-    if (bits > 128)
+    if (bits > 128) {
         PG_RETURN_NULL();
+    }
 
 	len = VARBITTOTALLEN(bits);
     res = palloc0(len);


### PR DESCRIPTION
Apply path from gpdb PR [#13600](https://github.com/greenplum-db/gpdb/pull/13600)

Turn off the enable_bitmapscan GUC variable in test file
ip4r-explain.sql due to different optimizations on branch master and
6X_STABLE. So this test file is different from the master branch.

Co-authored-by: Chen Mulong <chenmulong@gmail.com>
Co-authored-by: Xuebin Su <sxuebin@vmware.com>
Co-authored-by: Sasasu <i@sasa.su>