### PR TITLE
[Makefile] Remove useless variable NO_PGXS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-NO_PGXS := 1
-
 MODULE_big = ip4r
 
 ifndef NO_EXTENSION


### PR DESCRIPTION
The original ip4r extension uses this variable to control whether to
use PGXS or not when compiling it. When NO_PGXS=1, it assumes the ip4r
extension is built against an already installed server. When
NO_PGXS=0, it assumes the ip4r is built with Postgres source
code. Since we have decided to distribute ip4r as a separate module of
Greenplum and NO_PGXS isn't referenced in our source code, let's
remove it.

Upstream ip4r's Makefile: https://github.com/RhodiumToad/ip4r/blob/2bcdc143d106cfa4af507b4ecc0915ce2e6b364d/Makefile#L41